### PR TITLE
proper channel values

### DIFF
--- a/2_system_1/2_system_1.cpp
+++ b/2_system_1/2_system_1.cpp
@@ -60,7 +60,7 @@ void WriteStep(uint8_t channel, float value, bool trig) {
     note += ChannelNoteOffset(channel);
     note = Quantizer::apply(static_cast<Quantizer::Scale>(scale), note);
     float freq = daisysp::mtof(note);
-    hw.som.WriteCvOut(1 - channel, ftov(freq)); //cv channels switched??
+    hw.som.WriteCvOut(channel+1, ftov(freq));
     vcos[channel].SetFreq(freq);
     gates[channel] = trig;
 };

--- a/2_system_2/2_system_2.cpp
+++ b/2_system_2/2_system_2.cpp
@@ -65,7 +65,7 @@ static void AudioCallback(daisy::AudioHandle::InputBuffer in,
         vcfs[i].SetFreq(daisysp::fmap(knob_cv_combo(4 + i*2, 0 + i*2), 0.1f, 15000.0f));
         vcfs[i].SetRes(knob_cv_combo(5 + i*2, 1 + i*2));
         out_val[i] = adsrs[i].Process(gates[i]->State());
-        hw.som.WriteCvOut(i, out_val[1-i] * 5.0f);
+        hw.som.WriteCvOut(i+1, out_val[1-i] * 5.0f);
 
         uint8_t led = adsrs[i].GetCurrentSegment();
         if (led == 4) { led--; } // who knows


### PR DESCRIPTION
this whole time I've been confused why the channels seemed reversed, but actually it's just because
```
    /** Enum for addressing the CV Outputs via the WriteCvOut function. */
    enum
    {
        CV_OUT_BOTH = 0,
        CV_OUT_1,
        CV_OUT_2,
    };
```