### PR TITLE
Fix complete_voice release artifact target

### DIFF
--- a/4_complete_voice/Makefile
+++ b/4_complete_voice/Makefile
@@ -1,4 +1,4 @@
-TARGET = 4_dual_voice
+TARGET = complete_voice
 CPP_SOURCES = $(wildcard $(CCAM_PROJECT)/*.cpp)
 CPP_STANDARD = -std=gnu++20
 APP_TYPE = BOOT_NONE


### PR DESCRIPTION
## Summary
- rename the 4_complete_voice build target from 4_dual_voice to complete_voice
- align the emitted binary name with the release workflow packaging step

## Why
The v1.1.0 release workflow failed in the Build stable firmwares step because it looked for build/complete_voice.bin, but the project Makefile still targeted 4_dual_voice.

## Validation
- inspected failed workflow run 24854620861
- confirmed failure at cp: cannot stat 'build/complete_voice.bin'
- confirmed target mismatch in 4_complete_voice/Makefile